### PR TITLE
Update TaskManager data binding in MainWindow

### DIFF
--- a/To-Doodles/MainWindow.xaml
+++ b/To-Doodles/MainWindow.xaml
@@ -19,7 +19,8 @@
             </Grid.ColumnDefinitions>
             
             <!--ItemsSource="{d:SampleData ItemCount=5}"-->
-            <ListView Name="TaskManager" ItemsSource="{d:SampleData ItemCount=5}" Margin="10,30,10,10" Grid.RowSpan="3" Grid.ColumnSpan="2">
+            <ListView Name="TaskManager" ItemsSource="{Binding ActiveTasks}" Margin="10,30,10,10" Grid.RowSpan="3" Grid.ColumnSpan="2"
+                      d:DataContext="{d:DesignInstance }">
                 <ListView.ItemTemplate>
                     <DataTemplate DataType="local:Task">
                         <Grid Margin="0" HorizontalAlignment="Stretch">

--- a/To-Doodles/MainWindow.xaml.cs
+++ b/To-Doodles/MainWindow.xaml.cs
@@ -19,6 +19,9 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-
+        DataContext = new TaskManager();
+        // Add this after DataContext assignment in MainWindow.xaml.cs
+        var manager = (TaskManager)DataContext;
+        manager.CreateNewTask("Test Task", "This is a test description.", 1, 2, 3, 4);
     }
 }

--- a/To-Doodles/TaskManager.cs
+++ b/To-Doodles/TaskManager.cs
@@ -6,6 +6,10 @@ public class TaskManager
 {
     private static readonly ObservableCollection<Task> activeTasks = new();
     private static readonly ObservableCollection<Task> completeTasks = new();
+    
+    public ObservableCollection<Task> ActiveTasks => activeTasks;
+    public ObservableCollection<Task> CompleteTasks => completeTasks;
+    
     private static int nextTaskId = 1;
 
     public TaskManager()
@@ -45,7 +49,7 @@ public class TaskManager
     }
 
     // Methode zum Erstellen einer neuen Aufgabe
-    public static Task CreateNewTask(string title, string description, int wisdomExp, int patienceExp, int funExp, int creativityExp)
+    public Task CreateNewTask(string title, string description, int wisdomExp, int patienceExp, int funExp, int creativityExp)
     {
         var newTask = new Task
         {


### PR DESCRIPTION
### Description

This pull request introduces the following changes:
- Binds `TaskManager` to `MainWindow`, enabling centralized control.
- Updates the `ListView` component to use `ActiveTasks` as its data source.
- Adds public accessors for task collections to improve usability.

These changes enhance task management and simplify data flow in the application.