### PR TITLE
Add `EmptyToVisibilityConverter` and fix `TaskUI` bugs

### DIFF
--- a/To-Doodles/EmptyToVisibilityConverter.cs
+++ b/To-Doodles/EmptyToVisibilityConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace To_Doodles
+{
+    public class EmptyToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return string.IsNullOrWhiteSpace(value as string) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/To-Doodles/MainWindow.xaml
+++ b/To-Doodles/MainWindow.xaml
@@ -155,7 +155,8 @@
 
                 <!-- Dein eingebetteter "Dialog" -->
                     <local:TaskUI x:Name="ModalTaskUI" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0,0,10,10"/>
-                
+                        <!-- Durch das oben definierte Grid und dadurch dass die Alignments auf Stretch stehen
+                             füllt das TaskUI Fenster immer den unteren rechten Teil des MainWindow aus -->
             </Grid>
             
         </Border>

--- a/To-Doodles/MainWindow.xaml
+++ b/To-Doodles/MainWindow.xaml
@@ -24,7 +24,8 @@
                 <StackPanel>
 
                     <ListView ItemsSource="{Binding ActiveTasks}"
-                      d:DataContext="{d:DesignInstance}" ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                      d:DataContext="{d:DesignInstance}" ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                      BorderThickness="0,0,0,1" BorderBrush="LightGray">
 
                         <ListView.ItemTemplate>
 
@@ -70,7 +71,8 @@
                     </ListView>
 
                     <ListView ItemsSource="{Binding CompleteTasks}"
-                      d:DataContext="{d:DesignInstance}" ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                      d:DataContext="{d:DesignInstance}" ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                      BorderThickness="0">
 
                         <ListView.ItemTemplate>
 

--- a/To-Doodles/MainWindow.xaml
+++ b/To-Doodles/MainWindow.xaml
@@ -138,6 +138,11 @@
                 Panel.ZIndex="99">
             
             <Grid>
+                
+                <!-- Die RowDefinition der ersten Zeile und die ColumnDefinition der ersten Spalte sind 
+                    festgelegt auf 20 Pixel, damit ist der Abstand die das TaskUI Fenster zur linken und rechten Seite hat 
+                    fest, auch wenn es sich je nach Fenster ziehen vergrößert-->
+                
                 <Grid.RowDefinitions>
                     <RowDefinition Height="20"/>
                     <RowDefinition Height="*"/>

--- a/To-Doodles/MainWindow.xaml
+++ b/To-Doodles/MainWindow.xaml
@@ -19,47 +19,104 @@
             </Grid.ColumnDefinitions>
             
             <!--ItemsSource="{d:SampleData ItemCount=5}"-->
+            <ScrollViewer Grid.Row="1" Grid.RowSpan="2" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto">
 
-            <ListView Name="TaskManager" ItemsSource="{Binding ActiveTasks}" Margin="10,30,10,10" Grid.RowSpan="3" Grid.ColumnSpan="2"
-                      d:DataContext="{d:DesignInstance }">
+                <StackPanel>
 
-                <ListView.ItemTemplate>
-                    <DataTemplate DataType="local:Task">
-                        <Grid Margin="0" HorizontalAlignment="Stretch">
+                    <ListView ItemsSource="{Binding ActiveTasks}"
+                      d:DataContext="{d:DesignInstance}" ScrollViewer.VerticalScrollBarVisibility="Disabled">
 
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition/>
-                                
-                            </Grid.ColumnDefinitions>
-                            <CheckBox Grid.Column="0" Grid.RowSpan="2" Margin="5,5,0,0" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                        <ListView.ItemTemplate>
 
-                            <Grid Grid.Column="1">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
+                            <DataTemplate DataType="local:Task">
+                                <Grid Margin="0" HorizontalAlignment="Stretch">
 
-                                <Grid Grid.Row="0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition/>
+
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0" Margin="5,5,0,0" VerticalAlignment="Center" Text="{Binding Title}" FontSize="16"/>
-                                    <ComboBox Grid.Column="1" Margin="10,5,5,5" VerticalAlignment="Center" HorizontalAlignment="Right" Width="20">
-                                        <ComboBoxItem Content="Edit"/>
-                                        <ComboBoxItem Content="Delete"/>
-                                    </ComboBox>
+                                    <CheckBox Grid.Column="0" Grid.RowSpan="2" Margin="5,5,0,0" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+
+                                    <Grid Grid.Column="1">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <Grid Grid.Row="0">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" Margin="5,5,0,0" VerticalAlignment="Center" Text="{Binding Title}" FontSize="16"/>
+                                            <ComboBox Grid.Column="1" Margin="10,5,5,5" VerticalAlignment="Center" HorizontalAlignment="Right" Width="20">
+                                                <ComboBoxItem Content="Edit"/>
+                                                <ComboBoxItem Content="Delete"/>
+                                            </ComboBox>
+
+                                        </Grid>
+                                        <Rectangle Grid.Row="0" Grid.ColumnSpan="2" VerticalAlignment="Bottom" Height="1" Fill="#FFB0BEC5" Margin="5,0,5,0"/>
+                                        <TextBlock Grid.Row="1" Margin="5,0,5,5" VerticalAlignment="Top" Text="{Binding Description}" FontSize="12"/>
+                                    </Grid>
 
                                 </Grid>
-                                <Rectangle Grid.Row="0" Grid.ColumnSpan="2" VerticalAlignment="Bottom" Height="1" Fill="#FFB0BEC5" Margin="5,0,5,0"/>
-                                <TextBlock Grid.Row="1" Margin="5,0,5,5" VerticalAlignment="Top" Text="{Binding Description}" FontSize="12"/>
-                            </Grid>
-                        </Grid>
-                    </DataTemplate>
-                    
-                </ListView.ItemTemplate>
-            </ListView>
+
+                            </DataTemplate>
+
+                        </ListView.ItemTemplate>
+                        
+                    </ListView>
+
+                    <ListView ItemsSource="{Binding CompleteTasks}"
+                      d:DataContext="{d:DesignInstance}" ScrollViewer.VerticalScrollBarVisibility="Disabled">
+
+                        <ListView.ItemTemplate>
+
+                            <DataTemplate DataType="local:Task">
+                                <Grid Margin="0" HorizontalAlignment="Stretch">
+
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition/>
+
+                                    </Grid.ColumnDefinitions>
+                                    <CheckBox Grid.Column="0" Grid.RowSpan="2" Margin="5,5,0,0" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+
+                                    <Grid Grid.Column="1">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <Grid Grid.Row="0">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" Margin="5,5,0,0" VerticalAlignment="Center" Text="{Binding Title}" FontSize="16"/>
+                                            <ComboBox Grid.Column="1" Margin="10,5,5,5" VerticalAlignment="Center" HorizontalAlignment="Right" Width="20">
+                                                <ComboBoxItem Content="Edit"/>
+                                                <ComboBoxItem Content="Delete"/>
+                                            </ComboBox>
+
+                                        </Grid>
+                                        <Rectangle Grid.Row="0" Grid.ColumnSpan="2" VerticalAlignment="Bottom" Height="1" Fill="#FFB0BEC5" Margin="5,0,5,0"/>
+                                        <TextBlock Grid.Row="1" Margin="5,0,5,5" VerticalAlignment="Top" Text="{Binding Description}" FontSize="12"/>
+                                    </Grid>
+
+                                </Grid>
+
+                            </DataTemplate>
+
+                        </ListView.ItemTemplate>
+
+                    </ListView>
+
+                </StackPanel>
+                
+            </ScrollViewer>
+            
             <Button Grid.Column="1" Content="Button" Click="OpenTaskUI_Click" HorizontalAlignment="Center" Grid.Row="2" VerticalAlignment="Center" Width="60" Height="60" Margin="0,0,4,0">
                 <Button.Resources>
                     <Style TargetType="Border">
@@ -67,7 +124,9 @@
                     </Style>
                 </Button.Resources>
             </Button>
+            
             <ContentControl Name="TaskUI" Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="40,0,10,10"/>
+            
         </Grid>
     </Grid>
 </Window>

--- a/To-Doodles/MainWindow.xaml
+++ b/To-Doodles/MainWindow.xaml
@@ -33,9 +33,10 @@
 
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition/>
+                                        <ColumnDefinition Width="*"/>
 
                                     </Grid.ColumnDefinitions>
+                                    
                                     <CheckBox Grid.Column="0" Grid.RowSpan="2" Margin="5,5,0,0" VerticalAlignment="Center" HorizontalAlignment="Left"/>
 
                                     <Grid Grid.Column="1">
@@ -124,9 +125,35 @@
                     </Style>
                 </Button.Resources>
             </Button>
-            
-            <ContentControl Name="TaskUI" Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="40,0,10,10"/>
-            
+
+            <!--ContentControl Name="TaskUI" Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="40,0,10,10"/-->
+
         </Grid>
+        
+        <Border x:Name="ModalOverlay"
+                Background="#80000000"
+                Visibility="Collapsed"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                Panel.ZIndex="99">
+            
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="20"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="20"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Dein eingebetteter "Dialog" -->
+                    <local:TaskUI x:Name="ModalTaskUI" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0,0,10,10"/>
+                
+            </Grid>
+            
+        </Border>
+        
     </Grid>
 </Window>

--- a/To-Doodles/MainWindow.xaml.cs
+++ b/To-Doodles/MainWindow.xaml.cs
@@ -21,7 +21,7 @@ public partial class MainWindow : Window
         InitializeComponent();
         DataContext = new TaskManager();
         var manager = (TaskManager)DataContext;
-        manager.CreateNewTask("Test Task", "This is a test description.", 1, 2, 3, 4);
+        //manager.CreateNewTask("Test Task", "This is a test description.", 1, 2, 3, 4);
 
     }
 

--- a/To-Doodles/MainWindow.xaml.cs
+++ b/To-Doodles/MainWindow.xaml.cs
@@ -27,6 +27,6 @@ public partial class MainWindow : Window
 
     private void OpenTaskUI_Click(object sender, RoutedEventArgs e)
     {
-        TaskUI.Content = new TaskUI();
+        ModalOverlay.Visibility = Visibility.Visible;
     }
 }

--- a/To-Doodles/MainWindow.xaml.cs
+++ b/To-Doodles/MainWindow.xaml.cs
@@ -22,7 +22,7 @@ public partial class MainWindow : Window
         DataContext = new TaskManager();
         var manager = (TaskManager)DataContext;
         manager.CreateNewTask("Test Task", "This is a test description.", 1, 2, 3, 4);
-        
+
     }
 
     private void OpenTaskUI_Click(object sender, RoutedEventArgs e)

--- a/To-Doodles/MainWindow.xaml.cs
+++ b/To-Doodles/MainWindow.xaml.cs
@@ -21,7 +21,8 @@ public partial class MainWindow : Window
         InitializeComponent();
         DataContext = new TaskManager();
         var manager = (TaskManager)DataContext;
-        //manager.CreateNewTask("Test Task", "This is a test description.", 1, 2, 3, 4);
+        // manager.CreateNewTask("Test Task", "This is a test description.", 1, 2, 3, 4);
+        
 
     }
 

--- a/To-Doodles/TaskManager.cs
+++ b/To-Doodles/TaskManager.cs
@@ -17,7 +17,7 @@ public TaskManager()
         TaskStorage.Load(out var active, out var complete);
         
         foreach (var task in active)
-            completeTasks.Add(task);
+            activeTasks.Add(task);
         
         foreach (var task in complete)
             completeTasks.Add(task);

--- a/To-Doodles/TaskUI.xaml
+++ b/To-Doodles/TaskUI.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="To_Doodles.TaskUI"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Height="560" Width="300">
+        Height="Auto"
+        Width="Auto">
 
     <Grid Background="LightGray">
         <Grid.RowDefinitions>
@@ -19,8 +20,6 @@
                     <Setter Property="CornerRadius" Value="5"/>
                 </Style>
             </Button.Resources>
-
-
 
         </Button>
         

--- a/To-Doodles/TaskUI.xaml
+++ b/To-Doodles/TaskUI.xaml
@@ -1,44 +1,145 @@
 <UserControl x:Class="To_Doodles.TaskUI"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Height="Auto"
-        Width="Auto">
+       xmlns:toDoodles="clr-namespace:To_Doodles"
+       Height="Auto"
+       Width="Auto">
 
-    <Grid Background="LightGray">
+    <UserControl.Resources>
+        <toDoodles:EmptyToVisibilityConverter x:Key="EmptyToVisibilityConverter"/>
+    </UserControl.Resources>
+
+    <Grid Background="LightGray" Margin="10">
         <Grid.RowDefinitions>
-            <RowDefinition Height="62*"/>
-            <RowDefinition Height="375*"/>
-            <RowDefinition Height="47*"/>
+            <RowDefinition Height="Auto"/> <!-- Titel & Cancel -->
+            <RowDefinition Height="*"/>    <!-- Beschreibung -->
+            <RowDefinition Height="Auto"/> <!-- Zahlenfelder -->
+            <RowDefinition Height="Auto"/> <!-- Create-Button -->
         </Grid.RowDefinitions>
 
-
-
-        <Button Content="X" Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Top" Width="20" Height="20" Margin="0,5,5,0" Click="CloseButton_Click">
-
-            <Button.Resources>
-                <Style TargetType="Border">
-                    <Setter Property="CornerRadius" Value="5"/>
-                </Style>
-            </Button.Resources>
-
-        </Button>
-        
-        <Grid Grid.Row="2" Margin="0,0,0,0">
+        <!-- Titel + Cancel Button -->
+        <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <Button Content="Create" Grid.Column="1" HorizontalAlignment="Center" Margin="0,0,10,0" Width="80" Height="20">
+            <Grid Grid.Column="0" Height="30" Margin="0,5,5,5" VerticalAlignment="Top">
+                <TextBox Name="TitleBox"
+                         FontWeight="Bold"
+                         FontSize="14"
+                         VerticalContentAlignment="Center"/>
+                <TextBlock Text="Title"
+                           Foreground="Gray"
+                           FontSize="14"
+                           Padding="4,0,0,0"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Left"
+                           IsHitTestVisible="False"
+                           Visibility="{Binding Text, ElementName=TitleBox, Converter={StaticResource EmptyToVisibilityConverter}}"/>
+            </Grid>
 
+
+            <Button Content="X" Grid.Column="1" Width="20" Height="20" Margin="0,5,0,0"
+                    VerticalAlignment="Top" Click="CloseButton_Click">
                 <Button.Resources>
                     <Style TargetType="Border">
                         <Setter Property="CornerRadius" Value="5"/>
                     </Style>
                 </Button.Resources>
-
             </Button>
-
         </Grid>
+      
+        <!-- Description -->
+        <Grid Grid.Row="1" Margin="0,10,0,10">
+            <TextBox Name="DescriptionBox"
+                     TextWrapping="Wrap"
+                     AcceptsReturn="True"
+                     VerticalScrollBarVisibility="Auto"
+                     FontSize="12"
+                     VerticalContentAlignment="Top"
+                     Padding="5"/>
+            <TextBlock Text="Description"
+                       Foreground="Gray"
+                       FontSize="12"
+                       Padding="8,6,0,0"
+                       VerticalAlignment="Top"
+                       HorizontalAlignment="Left"
+                       IsHitTestVisible="False"
+                       Visibility="{Binding Text, ElementName=DescriptionBox, Converter={StaticResource EmptyToVisibilityConverter}}"/>
+        </Grid>
+
+        <!-- Zahlenfelder -->
+        <Grid Grid.Row="2" Margin="0,0,0,10">
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*"/>
+        <ColumnDefinition Width="*"/>
+        <ColumnDefinition Width="*"/>
+        <ColumnDefinition Width="*"/>
+    </Grid.ColumnDefinitions>
+
+    <!-- Wisdom -->
+    <Grid Grid.Column="0" Margin="2">
+        <TextBox Name="WisdomBox"
+                 TextAlignment="Center"
+                 VerticalContentAlignment="Center"
+                 FontSize="12"/>
+        <TextBlock Text="Wisdom"
+                   Foreground="Gray"
+                   FontSize="12"
+                   Padding="4,0,0,0"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Left"
+                   IsHitTestVisible="False"
+                   Visibility="{Binding Text, ElementName=WisdomBox, Converter={StaticResource EmptyToVisibilityConverter}}"/>
     </Grid>
+
+    <!-- Patience -->
+    <Grid Grid.Column="1" Margin="2">
+        <TextBox Name="PatienceBox"
+                 TextAlignment="Center"
+                 VerticalContentAlignment="Center"
+                 FontSize="12"/>
+        <TextBlock Text="Patience"
+                   Foreground="Gray"
+                   FontSize="12"
+                   Padding="4,0,0,0"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Left"
+                   IsHitTestVisible="False"
+                   Visibility="{Binding Text, ElementName=PatienceBox, Converter={StaticResource EmptyToVisibilityConverter}}"/>
+    </Grid>
+
+    <!-- Fun -->
+    <Grid Grid.Column="2" Margin="2">
+        <TextBox Name="FunBox"
+                 TextAlignment="Center"
+                 VerticalContentAlignment="Center"
+                 FontSize="12"/>
+        <TextBlock Text="Fun"
+                   Foreground="Gray"
+                   FontSize="12"
+                   Padding="4,0,0,0"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Left"
+                   IsHitTestVisible="False"
+                   Visibility="{Binding Text, ElementName=FunBox, Converter={StaticResource EmptyToVisibilityConverter}}"/>
+    </Grid>
+
+    <!-- Creativity -->
+    <Grid Grid.Column="3" Margin="2">
+        <TextBox Name="CreativityBox"
+                 TextAlignment="Center"
+                 VerticalContentAlignment="Center"
+                 FontSize="12"/>
+        <TextBlock Text="Creativity"
+                   Foreground="Gray"
+                   FontSize="12"
+                   Padding="4,0,0,0"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Left"
+                   IsHitTestVisible="False"
+                   Visibility="{Binding Text, ElementName=CreativityBox, Converter={StaticResource EmptyToVisibilityConverter}}"/>
+    </Grid>
+</Grid>
 </UserControl>

--- a/To-Doodles/TaskUI.xaml.cs
+++ b/To-Doodles/TaskUI.xaml.cs
@@ -30,4 +30,36 @@ namespace To_Doodles;
             this.Visibility = Visibility.Collapsed;
         }
     }
+
+    private void CreateButton_Click(object sender, RoutedEventArgs e)
+    {
+        var taskManager = (TaskManager)DataContext;
+
+        if (string.IsNullOrWhiteSpace(TitleBox.Text) || string.IsNullOrWhiteSpace(DescriptionBox.Text))
+        {
+            MessageBox.Show("Bitte Titel und Beschreibung ausfüllen.");
+            return;
+        }
+
+        if (!int.TryParse(WisdomBox.Text, out int wisdom) ||
+            !int.TryParse(PatienceBox.Text, out int patience) ||
+            !int.TryParse(FunBox.Text, out int fun) ||
+            !int.TryParse(CreativityBox.Text, out int creativity))
+        {
+            MessageBox.Show("Bitte gültige Zahlen für alle Eigenschaften eingeben.");
+            return;
+        }
+
+        var newTask = taskManager.CreateNewTask(
+            TitleBox.Text,
+            DescriptionBox.Text,
+            wisdom,
+            patience,
+            fun,
+            creativity
+        );
+
+        CloseButton_Click(sender, e);
+    }
+
 }

--- a/To-Doodles/TaskUI.xaml.cs
+++ b/To-Doodles/TaskUI.xaml.cs
@@ -20,9 +20,9 @@ namespace To_Doodles;
     private void CloseButton_Click(object sender, RoutedEventArgs e)
     {
         // Versucht, das UserControl aus seinem Parent-Panel zu entfernen
-        if (this.Parent is Panel panel)
+        if (Window.GetWindow(this) is MainWindow mainWindow)
         {
-            panel.Children.Remove(this);
+            mainWindow.ModalOverlay.Visibility = Visibility.Collapsed;
         }
         else
         {


### PR DESCRIPTION
### Description

This pull request introduces the `EmptyToVisibilityConverter` to handle title and description toggles in `TaskUI` more effectively. It also resolves multiple bugs in the `TaskManager` initialization and `CreateNewTask` calls. Additionally, the `TaskUI` layout is refactored, with UI elements now bound to validation logic.