### PR TITLE
Link CheckBox actions to Task completion status

### DIFF
--- a/To-Doodles/MainWindow.xaml
+++ b/To-Doodles/MainWindow.xaml
@@ -38,7 +38,9 @@
 
                                     </Grid.ColumnDefinitions>
                                     
-                                    <CheckBox Grid.Column="0" Grid.RowSpan="2" Margin="5,5,0,0" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                                    <CheckBox Grid.Column="0" Grid.RowSpan="2" Margin="5,5,0,0" 
+                                              VerticalAlignment="Center" HorizontalAlignment="Left" 
+                                              Checked="CheckBox_Checked"/>
 
                                     <Grid Grid.Column="1">
                                         <Grid.RowDefinitions>
@@ -84,7 +86,8 @@
                                         <ColumnDefinition/>
 
                                     </Grid.ColumnDefinitions>
-                                    <CheckBox Grid.Column="0" Grid.RowSpan="2" Margin="5,5,0,0" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                                    <CheckBox Grid.Column="0" Grid.RowSpan="2" Margin="5,5,0,0" VerticalAlignment="Center" HorizontalAlignment="Left"  Unchecked="CheckBox_Checked" 
+                                              IsChecked="{Binding IsComplete , Mode = OneWay}"/>
 
                                     <Grid Grid.Column="1">
                                         <Grid.RowDefinitions>

--- a/To-Doodles/MainWindow.xaml.cs
+++ b/To-Doodles/MainWindow.xaml.cs
@@ -30,4 +30,12 @@ public partial class MainWindow : Window
     {
         ModalOverlay.Visibility = Visibility.Visible;
     }
+
+    private void CheckBox_Checked(object sender, RoutedEventArgs e)
+    {
+        if (sender is CheckBox { DataContext: Task task })
+        {
+            task.ToggleComplete();
+        }
+    }
 }

--- a/To-Doodles/Task.cs
+++ b/To-Doodles/Task.cs
@@ -1,13 +1,27 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace To_Doodles;
 
-public class Task
+public class Task : INotifyPropertyChanged
 {
     public int Id { get; init; }
     public string Title { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
-    public bool IsComplete { get; private set; } = false;
+    public bool IsComplete
+    {
+        get => _isComplete;
+        set
+        {
+            if (_isComplete != value)
+            {
+                _isComplete = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsComplete)));
+            }
+        }
+    }
+    private bool _isComplete = false;
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     // Experience rewards
     public int WisdomExp { get; init; }
@@ -22,16 +36,19 @@ public class Task
     // toggelt den Status der Aufgabe und bewegt sie zwischen aktiv und abgeschlossen
     public void ToggleComplete()
     {
-        if (IsComplete) // Wenn die Aufgabe abgeschlossen ist, wird sie wieder aktiv
+        if (IsComplete)
         {
-            TaskManager.AddActiveTask(this);
+            IsComplete = false;
             TaskManager.RemoveCompleteTask(this);
+            if (!TaskManager.ActiveTasks.Contains(this))
+                TaskManager.AddActiveTask(this);
         }
-        else // Wenn die Aufgabe aktiv ist, wird sie abgeschlossen
+        else
         {
-            TaskManager.AddCompleteTask(this);
+            IsComplete = true;
             TaskManager.RemoveActiveTask(this);
+            if (!TaskManager.CompleteTasks.Contains(this))
+                TaskManager.AddCompleteTask(this);
         }
-        IsComplete = !IsComplete;
     }
 }

--- a/To-Doodles/TaskManager.cs
+++ b/To-Doodles/TaskManager.cs
@@ -7,8 +7,8 @@ public class TaskManager
     private static readonly ObservableCollection<Task> activeTasks = new();
     private static readonly ObservableCollection<Task> completeTasks = new();
     
-    public ObservableCollection<Task> ActiveTasks => activeTasks;
-    public ObservableCollection<Task> CompleteTasks => completeTasks;
+    public static ObservableCollection<Task> ActiveTasks => activeTasks;
+    public static ObservableCollection<Task> CompleteTasks => completeTasks;
     
     private static int nextTaskId = 1;
 


### PR DESCRIPTION
Refactor `ToggleComplete` method to ensure tasks correctly toggle between "Active" and "Completed" states in the UI. Bind `IsComplete` property to UI with `INotifyPropertyChanged`. Update `TaskManager` collections to static for consistency.